### PR TITLE
Default to '0' if token comes back as None in ChunkedReader

### DIFF
--- a/pyslet/http/messages.py
+++ b/pyslet/http/messages.py
@@ -269,7 +269,7 @@ class ChunkedReader(io.RawIOBase):
         if self.chunk_left == 0:
             self.src.readline()
         p = params.ParameterParser(self.src.readline().strip())
-        self.chunk_left = int(p.parse_token(), 16)
+        self.chunk_left = int(p.parse_token() or "0", 16)
         if self.chunk_left == 0:
             self.eof = True
             # read the trailing headers and CRLF

--- a/unittests/test_http_messages.py
+++ b/unittests/test_http_messages.py
@@ -179,6 +179,14 @@ class ChunkedTests(unittest.TestCase):
         self.assertTrue(r.read() == "0123456789ABCDEF01234", "unchunked data")
         self.assertTrue(src.read() == "trailer", "trailer left on the stream")
 
+    def test_chunked_reader_when_empty(self):
+        src = StringIO("")
+        r = ChunkedReader(src)
+        dest = StringIO()
+        r.readinto(dest)
+        self.assertTrue(dest.read() == "")
+        self.assertTrue(src.read() == "")
+
 
 class MessageTests(unittest.TestCase):
 


### PR DESCRIPTION
As far as i can tell, according to pep-0333 or pep-3333 we shouldn't be getting this far if the content-length is empty. Let me know if you want me to look into catching this higher up.