### PR TITLE
Include parent in parent/child expansion

### DIFF
--- a/pyslet/odata2/core.py
+++ b/pyslet/odata2/core.py
@@ -2073,9 +2073,8 @@ def _format_expand_list(expand):
     """Returns a list of unicode strings representing the *expand* rules."""
     result = []
     for k, v in dict_items(expand):
-        if not v:
-            result.append(k)
-        else:
+        result.append(k)
+        if v:
             result = result + list("%s/%s" % (k, x)
                                    for x in _format_expand_list(v))
     return result


### PR DESCRIPTION
Thanks for all your work on this Steve, and most importantly for publishing it!

In my use, it seems that the parent should be included in the expansion but is not, causing extra OData requests.  I couldn't figure out how to run the tests so none is included, sorry.

I may be missing something important/subtle in why this code is as it is!
Steven. 
